### PR TITLE
fix fmt.Println invocations

### DIFF
--- a/cmd/qoibench/main.go
+++ b/cmd/qoibench/main.go
@@ -23,7 +23,7 @@ func main() {
 	files, err := ioutil.ReadDir(dir)
 
 	if err != nil {
-		fmt.Println("Error: ", err)
+		fmt.Println("Error:", err)
 		return
 	}
 
@@ -33,13 +33,13 @@ func main() {
 		}
 		f, err := os.Open(dir + "/" + infile.Name())
 		if err != nil {
-			fmt.Println("Error opening file: ", err)
+			fmt.Println("Error opening file:", err)
 			return
 		}
 
 		img, _, err := image.Decode(f)
 		if err != nil {
-			fmt.Println("Error decoding file: ", err)
+			fmt.Println("Error decoding file:", err)
 			return
 		}
 

--- a/cmd/qoiconv/main.go
+++ b/cmd/qoiconv/main.go
@@ -20,13 +20,13 @@ func main() {
 
 	f, err := os.Open(infile)
 	if err != nil {
-		fmt.Println("Error opening file: ", err)
+		fmt.Println("Error opening file:", err)
 		return
 	}
 
 	img, _, err := image.Decode(f)
 	if err != nil {
-		fmt.Println("Error decoding file: ", err)
+		fmt.Println("Error decoding file:", err)
 		return
 	}
 
@@ -36,7 +36,7 @@ func main() {
 
 	of, err := os.Create(outfile)
 	if err != nil {
-		fmt.Println("Error creating file: %v", err)
+		fmt.Println("Error creating file:", err)
 		return
 	}
 	if strings.HasSuffix(outfile, ".png") {


### PR DESCRIPTION
fmt.Println() adds spaces between args, and doesn't support format strings